### PR TITLE
Added method `isTemplateString`

### DIFF
--- a/src/Charcoal/View/AbstractLoader.php
+++ b/src/Charcoal/View/AbstractLoader.php
@@ -86,6 +86,14 @@ abstract class AbstractLoader implements
             }
         }
 
+        /**
+         * Prevents the loader from passing a proper template through further
+         * procedures meant for a template identifier.
+         */
+        if ($this->isTemplateString($ident)) {
+            return $ident;
+        }
+
         $file = $this->findTemplateFile($ident);
         if ($file === null || $file === '') {
             return $ident;
@@ -265,6 +273,21 @@ abstract class AbstractLoader implements
         }
 
         return $path;
+    }
+
+    /**
+     * Determine if the variable is a template literal.
+     *
+     * This method looks for any line-breaks in the given string,
+     * which a file path would not allow.
+     *
+     * @param  string $ident The template being evaluated.
+     * @return boolean Returns TRUE if the given value is most likely the template contents
+     *     as opposed to a template identifier (file path).
+     */
+    protected function isTemplateString($ident)
+    {
+        return strpos($ident, PHP_EOL) !== false;
     }
 
     /**

--- a/src/Charcoal/View/Mustache/MustacheLoader.php
+++ b/src/Charcoal/View/Mustache/MustacheLoader.php
@@ -19,6 +19,21 @@ class MustacheLoader extends AbstractLoader implements
     MustacheLoaderInterface
 {
     /**
+     * Determine if the variable is a template literal.
+     *
+     * This method looks for any tag delimiters in the given string,
+     * which a file path would most likely not have.
+     *
+     * @todo   Add support for custom delimiters.
+     * @param  string $ident The template being evaluated.
+     * @return boolean
+     */
+    protected function isTemplateString($ident)
+    {
+        return strpos($ident, '{{') !== false || parent::isTemplateString($ident);
+    }
+
+    /**
      * Convert an identifier to a file path.
      *
      * @param  string $ident The template identifier to convert to a filename.

--- a/src/Charcoal/View/Php/PhpLoader.php
+++ b/src/Charcoal/View/Php/PhpLoader.php
@@ -14,6 +14,21 @@ use Charcoal\View\LoaderInterface;
 class PhpLoader extends AbstractLoader implements LoaderInterface
 {
     /**
+     * Determine if the variable is a template literal.
+     *
+     * This method looks for any PHP tags in the given string,
+     * which a file path would most likely not have.
+     *
+     * @todo   Add support for custom delimiters.
+     * @param  string $ident The template being evaluated.
+     * @return boolean
+     */
+    protected function isTemplateString($ident)
+    {
+        return strpos($ident, '<?') !== false || parent::isTemplateString($ident);
+    }
+
+    /**
      * Convert an identifier to a file path.
      *
      * @param string $ident The identifier to convert.

--- a/src/Charcoal/View/Twig/TwigLoader.php
+++ b/src/Charcoal/View/Twig/TwigLoader.php
@@ -24,6 +24,21 @@ class TwigLoader extends AbstractLoader implements
     TwigSourceContextLoaderInterface
 {
     /**
+     * Determine if the variable is a template literal.
+     *
+     * This method looks for any tag delimiters in the given string,
+     * which a file path would most likely not have.
+     *
+     * @todo   Add support for custom delimiters.
+     * @param  string $ident The template being evaluated.
+     * @return boolean
+     */
+    protected function isTemplateString($ident)
+    {
+        return strpos($ident, '{%') !== false || parent::isTemplateString($ident);
+    }
+
+    /**
      * Convert an identifier to a file path.
      *
      * @param  string $ident The identifier to convert.


### PR DESCRIPTION
The very simple method allows template loaders to validate if a given value is maybe the contents of a template or just a template identifier (file path).

Prevents the loader from passing what could be a raw template through further procedures meant for a template identifier.