### PR TITLE
Normalize cache setting and path for Mustache and Twig

### DIFF
--- a/src/Charcoal/View/AbstractEngine.php
+++ b/src/Charcoal/View/AbstractEngine.php
@@ -33,6 +33,13 @@ abstract class AbstractEngine implements
     private $loader;
 
     /**
+     * The cache option.
+     *
+     * @var mixed
+     */
+    private $cache;
+
+    /**
      * @return string
      */
     abstract public function type();
@@ -50,6 +57,33 @@ abstract class AbstractEngine implements
     {
         $this->setLogger($data['logger']);
         $this->setLoader($data['loader']);
+
+        if (isset($data['cache'])) {
+            $this->setCache($data['cache']);
+        }
+    }
+
+    /**
+     * Set the engine's cache implementation.
+     *
+     * @param  mixed $cache A engine cache implementation,
+     *                      an absolute path to the compiled views,
+     *                      a boolean to enable/disable cache.
+     * @return void
+     */
+    protected function setCache($cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Get the engine's cache implementation.
+     *
+     * @return mixed
+     */
+    protected function cache()
+    {
+        return $this->cache;
     }
 
     /**

--- a/src/Charcoal/View/Mustache/MustacheEngine.php
+++ b/src/Charcoal/View/Mustache/MustacheEngine.php
@@ -18,7 +18,8 @@ use Charcoal\View\Mustache\HelpersInterface;
  */
 class MustacheEngine extends AbstractEngine
 {
-    const DEFAULT_CACHE = '../cache/mustache';
+    const DEFAULT_CACHE_PATH = '../cache/mustache';
+
     /**
      * A collection of helpers.
      *
@@ -32,14 +33,6 @@ class MustacheEngine extends AbstractEngine
      * @var Mustache_Engine
      */
     private $mustache;
-
-
-    /**
-     * The cache path.
-     *
-     * @var string
-     */
-    private $cache = self::DEFAULT_CACHE;
 
     /**
      * @return string
@@ -61,10 +54,6 @@ class MustacheEngine extends AbstractEngine
         if (isset($data['helpers'])) {
             $this->setHelpers($data['helpers']);
         }
-
-        if (isset($data['cache'])) {
-            $this->cache = $data['cache'];
-        }
     }
 
     /**
@@ -85,7 +74,7 @@ class MustacheEngine extends AbstractEngine
     protected function createMustache()
     {
         $mustache = new Mustache_Engine([
-            'cache'             => $this->cache,
+            'cache'             => $this->cache(),
             'loader'            => $this->loader(),
             'partials_loader'   => $this->loader(),
             'strict_callables'  => true,
@@ -93,6 +82,25 @@ class MustacheEngine extends AbstractEngine
         ]);
 
         return $mustache;
+    }
+
+    /**
+     * Set the engine's cache implementation.
+     *
+     * @param  mixed $cache A Mustache cache option.
+     * @return void
+     */
+    protected function setCache($cache)
+    {
+        /**
+         * If FALSE is specified, the value is converted to NULL
+         * because Mustache internally requires NULL to disable the cache.
+         */
+        if ($cache === false) {
+            $cache = null;
+        }
+
+        parent::setCache($cache);
     }
 
     /**

--- a/src/Charcoal/View/Php/PhpEngine.php
+++ b/src/Charcoal/View/Php/PhpEngine.php
@@ -25,7 +25,6 @@ class PhpEngine extends AbstractEngine
      */
     public function renderTemplate($templateString, $context)
     {
-
         $arrayContext = json_decode(json_encode($context), true);
         // Prevents leaking global variable by forcing anonymous scope
         $render = function($templateString, array $context) {

--- a/src/Charcoal/View/Twig/TwigEngine.php
+++ b/src/Charcoal/View/Twig/TwigEngine.php
@@ -13,6 +13,8 @@ use Charcoal\View\AbstractEngine;
  */
 class TwigEngine extends AbstractEngine
 {
+    const DEFAULT_CACHE_PATH = '../cache/twig';
+
     /**
      * @var Twig_Environment $twig
      */
@@ -43,12 +45,31 @@ class TwigEngine extends AbstractEngine
     protected function createTwig()
     {
         $twig = new Twig_Environment($this->loader(), [
-            'cache'     => 'twig_cache',
+            'cache'     => $this->cache(),
             'charset'   => 'utf-8',
             'debug'     => false
         ]);
 
         return $twig;
+    }
+
+    /**
+     * Set the engine's cache implementation.
+     *
+     * @param  mixed $cache A Twig cache option.
+     * @return void
+     */
+    protected function setCache($cache)
+    {
+        /**
+         * If NULL is specified, the value is converted to FALSE
+         * because Twig internally requires FALSE to disable the cache.
+         */
+        if ($cache === null) {
+            $cache = false;
+        }
+
+        parent::setCache($cache);
     }
 
     /**

--- a/src/Charcoal/View/ViewConfig.php
+++ b/src/Charcoal/View/ViewConfig.php
@@ -7,6 +7,10 @@ use InvalidArgumentException;
 // Module `charcoal-config` dependencies
 use Charcoal\Config\AbstractConfig;
 
+// Intra-module (`charcoal-view`) depentencies
+use Charcoal\View\Mustache\MustacheEngine;
+use Charcoal\View\Twig\TwigEngine;
+
 /**
  * View configuration.
  */
@@ -36,11 +40,13 @@ class ViewConfig extends AbstractConfig
             'paths' => [],
             'engines' => [
                 'mustache'      => [
-                    'cache' => '../cache/mustache'
+                    'cache' => MustacheEngine::DEFAULT_CACHE_PATH
                 ],
                 'php'           => [],
                 'php-mustache'  => [],
-                'twig'          => []
+                'twig'          => [
+                    'cache' => TwigEngine::DEFAULT_CACHE_PATH
+                ]
             ],
             'default_engine' => 'mustache'
         ];

--- a/src/Charcoal/View/ViewServiceProvider.php
+++ b/src/Charcoal/View/ViewServiceProvider.php
@@ -64,6 +64,7 @@ class ViewServiceProvider implements ServiceProviderInterface
         $this->registerLoaderServices($container);
         $this->registerEngineServices($container);
         $this->registerMustacheTemplatingServices($container);
+        $this->registerTwigTemplatingServices($container);
         $this->registerViewServices($container);
     }
 
@@ -164,7 +165,8 @@ class ViewServiceProvider implements ServiceProviderInterface
         $container['view/engine/twig'] = function (Container $container) {
             return new TwigEngine([
                 'logger'    => $container['logger'],
-                'loader'    => $container['view/loader/twig']
+                'loader'    => $container['view/loader/twig'],
+                'cache'     => $container['view/twig/cache']
             ]);
         };
 
@@ -218,6 +220,22 @@ class ViewServiceProvider implements ServiceProviderInterface
         $container['view/mustache/cache'] = function (Container $container) {
             $viewConfig = $container['view/config'];
             return $viewConfig['engines.mustache.cache'];
+        };
+    }
+
+    /**
+     * @param Container $container The DI container.
+     * @return void
+     */
+    protected function registerTwigTemplatingServices(Container $container)
+    {
+        /**
+         * @param  Container $container A container instance.
+         * @return string|null
+         */
+        $container['view/twig/cache'] = function (Container $container) {
+            $viewConfig = $container['view/config'];
+            return $viewConfig['engines.twig.cache'];
         };
     }
 

--- a/tests/Charcoal/View/AbstractEngineTest.php
+++ b/tests/Charcoal/View/AbstractEngineTest.php
@@ -28,13 +28,13 @@ class AbstractEngineTest extends PHPUnit_Framework_TestCase
     {
         $logger = new NullLogger();
         $loader = new MustacheLoader([
-            'logger'=>$logger,
-            'base_path'=>__DIR__,
-            'paths'=>['Mustache/templates']
+            'logger'    => $logger,
+            'base_path' => __DIR__,
+            'paths'     => ['Mustache/templates']
         ]);
         $this->obj = $this->getMockForAbstractClass(AbstractEngine::class, [[
-            'logger'=>$logger,
-            'loader'=>$loader
+            'logger' => $logger,
+            'loader' => $loader
         ]]);
     }
 

--- a/tests/Charcoal/View/ViewConfigTest.php
+++ b/tests/Charcoal/View/ViewConfigTest.php
@@ -31,7 +31,7 @@ class ViewConfigTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['cache'=>'../cache/mustache'], $this->obj['engines.mustache']);
         $this->assertEquals([], $this->obj['engines.php']);
         $this->assertEquals([], $this->obj['engines.php-mustache']);
-        $this->assertEquals([], $this->obj['engines.twig']);
+        $this->assertEquals(['cache'=>'../cache/twig'], $this->obj['engines.twig']);
         $this->assertEquals('mustache', $this->obj['default_engine']);
     }
 


### PR DESCRIPTION
Changes:
- `AbstractEngine`: Added setter/getter for "cache" option
- `MustacheEngine`: Renamed `DEFAULT_CACHE` to `DEFAULT_CACHE_PATH`
- `MustacheEngine`: Overridden cache setter to normalize value for Mustache
- `TwigEngine`: Added `DEFAULT_CACHE_PATH`
- `TwigEngine`: Overridden cache setter to normalize value for Twig
- `ViewConfig`: Used `DEFAULT_CACHE_PATH` constants from `MustacheEngine` and `TwigEngine`
- Provider: Added "view/twig/cache"