### PR TITLE
[WIP] Add Template Loader Registry

### DIFF
--- a/src/Charcoal/View/AbstractEngine.php
+++ b/src/Charcoal/View/AbstractEngine.php
@@ -95,6 +95,24 @@ abstract class AbstractEngine implements
     }
 
     /**
+     * @param string $varName The name of the variable to get template ident from.
+     * @return string
+     */
+    public function dynamicTemplate($varName)
+    {
+        return $this->loader()->dynamicTemplate($varName);
+    }
+
+    /**
+     * @param string $varName The name of the variable to get template ident from.
+     * @return boolean
+     */
+    public function hasDynamicTemplate($varName)
+    {
+        return $this->loader()->hasDynamicTemplate($varName);
+    }
+
+    /**
      * @param string      $varName       The name of the variable to set this template unto.
      * @param string|null $templateIdent The "dynamic template" to set. null to clear.
      * @return void
@@ -102,6 +120,14 @@ abstract class AbstractEngine implements
     public function setDynamicTemplate($varName, $templateIdent)
     {
         $this->loader()->setDynamicTemplate($varName, $templateIdent);
+    }
+
+    /**
+     * @return \Charcoal\View\LoaderRegistryInterface
+     */
+    public function templateRegistry()
+    {
+        return $this->loader()->templateRegistry();
     }
 
     /**
@@ -127,17 +153,6 @@ abstract class AbstractEngine implements
         return $this->cache;
     }
 
-
-    /**
-     * @return LoaderInterface
-     */
-    protected function loader()
-    {
-        return $this->loader;
-    }
-
-
-
     /**
      * @param LoaderInterface $loader A loader instance.
      * @return void
@@ -145,5 +160,13 @@ abstract class AbstractEngine implements
     private function setLoader(LoaderInterface $loader)
     {
         $this->loader = $loader;
+    }
+
+    /**
+     * @return LoaderInterface
+     */
+    protected function loader()
+    {
+        return $this->loader;
     }
 }

--- a/src/Charcoal/View/AbstractTemplateRegistry.php
+++ b/src/Charcoal/View/AbstractTemplateRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Charcoal\View;
+
+use InvalidArgumentException;
+
+/**
+ * Base Template Registry
+ */
+abstract class AbstractTemplateRegistry implements
+    LoaderRegistryInterface
+{
+    /**
+     * Alias of {@see LoaderRegistryInterface::has()}.
+     *
+     * @param  string $key The template key.
+     * @return boolean
+     */
+    public function offsetExists($key)
+    {
+        return $this->has($key);
+    }
+
+    /**
+     * Alias of {@see LoaderRegistryInterface::get()}.
+     *
+     * @param  string $key The template key.
+     * @return string|null The view assigned to the $key or NULL if template is missing.
+     */
+    public function offsetGet($key)
+    {
+        return $this->get($key);
+    }
+
+    /**
+     * Alias of {@see LoaderRegistryInterface::set()}.
+     *
+     * @param  string $key      The template key.
+     * @param  mixed  $template The template view.
+     * @return void
+     */
+    public function offsetSet($key, $template)
+    {
+        $this->set($key, $template);
+    }
+
+    /**
+     * Alias of {@see LoaderRegistryInterface::remove()}.
+     *
+     * @param  string $key The template key.
+     * @return void
+     */
+    public function offsetUnset($key)
+    {
+        $this->remove($key);
+    }
+}

--- a/src/Charcoal/View/AbstractView.php
+++ b/src/Charcoal/View/AbstractView.php
@@ -90,6 +90,24 @@ abstract class AbstractView implements
     }
 
     /**
+     * @param string $varName The name of the variable to get template ident from.
+     * @return string
+     */
+    public function dynamicTemplate($varName)
+    {
+        return $this->engine()->dynamicTemplate($varName);
+    }
+
+    /**
+     * @param string $varName The name of the variable to get template ident from.
+     * @return boolean
+     */
+    public function hasDynamicTemplate($varName)
+    {
+        return $this->engine()->hasDynamicTemplate($varName);
+    }
+
+    /**
      * @param string      $varName       The name of the variable to set this template unto.
      * @param string|null $templateIdent The "dynamic template" to set. null to clear.
      * @return void
@@ -97,6 +115,14 @@ abstract class AbstractView implements
     public function setDynamicTemplate($varName, $templateIdent)
     {
         $this->engine()->setDynamicTemplate($varName, $templateIdent);
+    }
+
+    /**
+     * @return \Charcoal\View\LoaderRegistryInterface
+     */
+    public function templateRegistry()
+    {
+        return $this->engine()->templateRegistry();
     }
 
     /**

--- a/src/Charcoal/View/DynamicTemplateRegistry.php
+++ b/src/Charcoal/View/DynamicTemplateRegistry.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Charcoal\View;
+
+use InvalidArgumentException;
+
+/**
+ * Dynamic Template Registry
+ */
+class DynamicTemplateRegistry extends AbstractTemplateRegistry
+{
+    /**
+     * Store of registered template keys.
+     *
+     * @var boolean[]
+     */
+    private $registered = [];
+
+    /**
+     * Store of template views.
+     *
+     * @var boolean[]
+     */
+    private $templates = [];
+
+    /**
+     * Store of protected template keys.
+     *
+     * @var boolean[]
+     */
+    private $protected = [];
+
+    /**
+     * Store of single-use templates.
+     *
+     * @var {string|boolean}[]
+     */
+    private $once = [];
+
+    /**
+     * Create new dynamic template collection
+     *
+     * @param array $templates Pre-populate collection with these templates.
+     */
+    public function __construct(array $templates = [])
+    {
+        $this->replace($templates);
+    }
+
+    /**
+     * Set the template for the given key.
+     *
+     * @param  string $key      The template key.
+     * @param  string $template The template view.
+     * @throws InvalidArgumentException If the template is protected.
+     * @return void
+     */
+    public function set($key, $template)
+    {
+        if (isset($this->protected[$key])) {
+            if (isset($this->templates[$key]) || isset($this->once[$key])) {
+                throw new InvalidArgumentException(
+                    sprintf('Cannot remove protected dynamic template "%s".', $key)
+                );
+            }
+        }
+
+        $this->templates[$key]  = $template;
+        $this->registered[$key] = true;
+    }
+
+    /**
+     * Retrieve the template by key.
+     *
+     * @param  string $key The template key.
+     * @return string|null The view assigned to the $key or NULL if template is missing.
+     */
+    public function get($key)
+    {
+        if (!isset($this->registered[$key])) {
+            return null;
+        }
+
+        if (isset($this->once[$key])) {
+            $template = $this->once[$key];
+            if ($template !== true) {
+                if (isset($this->protected[$key])) {
+                    $this->once[$key] = true;
+                } elseif (isset($this->templates[$key])) {
+                    unset($this->once[$key]);
+                } else {
+                    unset($this->registered[$key], $this->once[$key]);
+                }
+
+                return $template;
+            } else {
+                return null;
+            }
+        }
+
+        return $this->templates[$key];
+    }
+
+    /**
+     * Determine if a template exists in the collection by key.
+     *
+     * @param  string $key The template key.
+     * @return boolean
+     */
+    public function has($key)
+    {
+        return isset($this->registered[$key]);
+    }
+
+    /**
+     * Remove template from collection by key.
+     *
+     * @param  string  $key   The template key.
+     * @param  boolean $force To remove protected templates.
+     * @throws InvalidArgumentException If the template is protected.
+     * @return void
+     */
+    public function remove($key, $force = false)
+    {
+        if (!isset($this->registered[$key])) {
+            return;
+        }
+
+        if ($force === true) {
+            unset($this->registered[$key], $this->templates[$key], $this->once[$key], $this->protected[$key]);
+            return;
+        }
+
+        if (isset($this->protected[$key])) {
+            throw new InvalidArgumentException(
+                sprintf('Cannot remove protected dynamic template "%s".', $key)
+            );
+        }
+
+        unset($this->registered[$key], $this->templates[$key], $this->once[$key]);
+    }
+
+    /**
+     * Protects the template from being replaced or removed.
+     *
+     * Note: The template view can be assigned after enabling protection.
+     *
+     * @param  string      $key      The template key to protect from being changed.
+     * @param  string|null $template Optional. The template view to protect.
+     * @return void
+     */
+    public function protect($key, $template = null)
+    {
+        $this->protected[$key] = true;
+
+        if ($template !== null) {
+            $this->set($key, $template);
+        }
+    }
+
+    /**
+     * Set the template for the given key to be is used at most once.
+     *
+     * The `once()` method is identical to `set()`, except that the template
+     * is unbound after its first retrieval.
+     *
+     * Note: If the template is protected, the template cannot be rebound.
+     *
+     * @param  string      $key      The template key to limit.
+     * @param  string|null $template Optional. The template view to limit.
+     * @throws InvalidArgumentException If the template is protected.
+     * @return void
+     */
+    public function once($key, $template = null)
+    {
+        if (isset($this->protected[$key]) && isset($this->once[$key])) {
+            throw new InvalidArgumentException(
+                sprintf('Cannot remove protected dynamic template "%s".', $key)
+            );
+        }
+
+        $this->once[$key]       = $template;
+        $this->registered[$key] = true;
+    }
+
+    /**
+     * Add template(s) to collection, replacing existing templates with the same key.
+     *
+     * @param  array $templates Key-value array of templates to replace to this collection.
+     * @return void
+     */
+    public function replace(array $templates)
+    {
+        foreach ($templates as $key => $template) {
+            $this->set($key, $template);
+        }
+    }
+
+    /**
+     * Retrieve all registered template keys.
+     *
+     * @return string[]
+     */
+    public function registeredTemplates()
+    {
+        return array_keys($this->templates);
+    }
+
+    /**
+     * Remove all templates from collection.
+     *
+     * @param  boolean $force If TRUE, protected templates are also removed.
+     * @return void
+     */
+    public function clear($force = false)
+    {
+        if ($force === true) {
+            $this->registered = [];
+            $this->protected  = [];
+            $this->templates  = [];
+            $this->once       = [];
+        } else {
+            $this->registered = array_intersect_key($this->registered, $this->protected);
+            $this->templates  = array_intersect_key($this->templates, $this->protected);
+            $this->once       = array_intersect_key($this->once, $this->protected);
+        }
+    }
+}

--- a/src/Charcoal/View/GenericTemplateRegistry.php
+++ b/src/Charcoal/View/GenericTemplateRegistry.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Charcoal\View;
+
+/**
+ * Generic Template Registry
+ */
+class GenericTemplateRegistry extends AbstractTemplateRegistry
+{
+    /**
+     * Store of templates.
+     *
+     * @var string[]
+     */
+    private $templates = [];
+
+    /**
+     * Create new dynamic template collection
+     *
+     * @param array $templates Pre-populate collection with these templates.
+     */
+    public function __construct(array $templates = [])
+    {
+        $this->replace($templates);
+    }
+
+    /**
+     * Set the template for the given key.
+     *
+     * @param  string $key      The template key.
+     * @param  string $template The template view.
+     * @return void
+     */
+    public function set($key, $template)
+    {
+        $this->templates[$key] = $template;
+    }
+
+    /**
+     * Retrieve the template by key.
+     *
+     * @param  string $key The template key.
+     * @return string|null The view assigned to the $key or NULL if template is missing.
+     */
+    public function get($key)
+    {
+        if (!isset($this->templates[$key])) {
+            return null;
+        }
+
+        return $this->templates[$key];
+    }
+
+    /**
+     * Determine if a template exists in the collection by key.
+     *
+     * @param  string $key The template key.
+     * @return boolean
+     */
+    public function has($key)
+    {
+        return isset($this->templates[$key]);
+    }
+
+    /**
+     * Remove template from collection by key.
+     *
+     * @param  string $key The template key.
+     * @return void
+     */
+    public function remove($key)
+    {
+        if (!isset($this->templates[$key])) {
+            return;
+        }
+
+        unset($this->templates[$key]);
+    }
+
+    /**
+     * Add template(s) to collection, replacing existing templates with the same key.
+     *
+     * @param  array $templates Key-value array of templates to replace to this collection.
+     * @return void
+     */
+    public function replace(array $templates)
+    {
+        foreach ($templates as $key => $template) {
+            $this->set($key, $template);
+        }
+    }
+
+    /**
+     * Retrieve all registered template keys.
+     *
+     * @return string[]
+     */
+    public function registeredTemplates()
+    {
+        return array_keys($this->templates);
+    }
+
+    /**
+     * Remove all templates from collection.
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->templates = [];
+    }
+}

--- a/src/Charcoal/View/LoaderInterface.php
+++ b/src/Charcoal/View/LoaderInterface.php
@@ -12,17 +12,4 @@ interface LoaderInterface
      * @return string
      */
     public function load($ident);
-
-    /**
-     * @param  string      $varName       The name of the variable to set this template unto.
-     * @param  string|null $templateIdent The "dynamic template" to set. null to clear.
-     * @return void
-     */
-    public function setDynamicTemplate($varName, $templateIdent);
-
-    /**
-     * @param  string $varName The name of the variable to get template ident from.
-     * @return string
-     */
-    public function dynamicTemplate($varName);
 }

--- a/src/Charcoal/View/LoaderRegistryInterface.php
+++ b/src/Charcoal/View/LoaderRegistryInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Charcoal\View;
+
+/**
+ * Template Loader Registry Interface
+ */
+interface LoaderRegistryInterface extends \ArrayAccess
+{
+    /**
+     * Set the template for the given key.
+     *
+     * @param  string $ident    The template key.
+     * @param  string $template The template view.
+     * @return void
+     */
+    public function set($ident, $template);
+
+    /**
+     * Retrieve the template by key.
+     *
+     * @param  string $ident The template key.
+     * @return string|null The view assigned to the $ident or NULL if template is missing.
+     */
+    public function get($ident);
+
+    /**
+     * Determine if a template exists in the collection by key.
+     *
+     * @param  string $ident The template key.
+     * @return boolean
+     */
+    public function has($ident);
+
+    /**
+     * Remove template from collection by key.
+     *
+     * @param  string $ident The template key.
+     * @return void
+     */
+    public function remove($ident);
+
+    /**
+     * Add template(s) to collection, replacing existing templates with the same key.
+     *
+     * @param  array $templates Key-value array of templates to replace to this collection.
+     * @return void
+     */
+    public function replace(array $templates);
+
+    /**
+     * Retrieve all registered template keys.
+     *
+     * @return string[]
+     */
+    public function registeredTemplates();
+
+    /**
+     * Remove all templates from collection.
+     *
+     * @return void
+     */
+    public function clear();
+}

--- a/src/Charcoal/View/Mustache/MustacheLoader.php
+++ b/src/Charcoal/View/Mustache/MustacheLoader.php
@@ -2,15 +2,18 @@
 
 namespace Charcoal\View\Mustache;
 
+use Exception;
+
 // From Mustache
 use Mustache_Loader as MustacheLoaderInterface;
+use Mustache_Exception_UnknownTemplateException as UnknownTemplateException;
 
 // From 'charcoal-view'
 use Charcoal\View\AbstractLoader;
 use Charcoal\View\LoaderInterface;
 
 /**
- * Mustache Template Loader
+ * Mustache Template Loader Adaptor
  *
  * Finds a Mustache template file in a collection of directory paths.
  */
@@ -18,6 +21,27 @@ class MustacheLoader extends AbstractLoader implements
     LoaderInterface,
     MustacheLoaderInterface
 {
+    /**
+     * Handle when a template is not found.
+     *
+     * @param  string $ident The template ident.
+     * @throws Exception If the template is not found.
+     * @return string
+     */
+    public function handleNotFound($ident)
+    {
+        if ($this->silent() === false) {
+            $e = new UnknownTemplateException($ident);
+            throw new Exception(sprintf('Unknown template: "%s"', $ident), 0, $e);
+        }
+
+        $this->logger->notice(
+            sprintf('Unable to find template "%s"', $ident)
+        );
+
+        return '';
+    }
+
     /**
      * Convert an identifier to a file path.
      *

--- a/src/Charcoal/View/Php/PhpLoader.php
+++ b/src/Charcoal/View/Php/PhpLoader.php
@@ -2,17 +2,39 @@
 
 namespace Charcoal\View\Php;
 
+use Exception;
+
 // From 'charcoal-view'
 use Charcoal\View\AbstractLoader;
 use Charcoal\View\LoaderInterface;
 
 /**
- * PHP Template Loader
+ * PHP Template Loader Adaptor
  *
  * Finds a PHP template file in a collection of directory paths.
  */
 class PhpLoader extends AbstractLoader implements LoaderInterface
 {
+    /**
+     * Handle when a template is not found.
+     *
+     * @param  string $ident The template ident.
+     * @throws Exception If the template is not found.
+     * @return string
+     */
+    public function handleNotFound($ident)
+    {
+        if ($this->silent() === false) {
+            throw new Exception(sprintf('Unknown template: "%s"', $ident));
+        }
+
+        $this->logger->notice(
+            sprintf('Unable to find template "%s"', $ident)
+        );
+
+        return '';
+    }
+
     /**
      * Convert an identifier to a file path.
      *

--- a/src/Charcoal/View/Twig/TwigLoader.php
+++ b/src/Charcoal/View/Twig/TwigLoader.php
@@ -2,7 +2,10 @@
 
 namespace Charcoal\View\Twig;
 
+use Exception;
+
 // From Twig
+use Twig\Error\LoaderError as TwigLoaderError;
 use Twig\Loader\LoaderInterface as TwigLoaderInterface;
 use Twig\Loader\ExistsLoaderInterface as TwigExistsLoaderInterface;
 use Twig\Loader\SourceContextLoaderInterface as TwigSourceContextLoaderInterface;
@@ -13,7 +16,7 @@ use Charcoal\View\AbstractLoader;
 use Charcoal\View\LoaderInterface;
 
 /**
- * Twig Template Loader
+ * Twig Template Loader Adaptor
  *
  * Finds a Twig template file in a collection of directory paths.
  */
@@ -23,6 +26,27 @@ class TwigLoader extends AbstractLoader implements
     TwigExistsLoaderInterface,
     TwigSourceContextLoaderInterface
 {
+    /**
+     * Handle when a template is not found.
+     *
+     * @param  string $ident The template ident.
+     * @throws Exception If the template is not found.
+     * @return string
+     */
+    public function handleNotFound($ident)
+    {
+        if ($this->silent() === false) {
+            $e = new TwigLoaderError(sprintf('Unknown template: "%s"', $ident));
+            throw new Exception($e->getMessage(), 0, $e);
+        }
+
+        $this->logger->notice(
+            sprintf('Unable to find template "%s"', $ident)
+        );
+
+        return '';
+    }
+
     /**
      * Convert an identifier to a file path.
      *

--- a/src/Charcoal/View/ViewServiceProvider.php
+++ b/src/Charcoal/View/ViewServiceProvider.php
@@ -10,6 +10,7 @@ use Pimple\Container;
 use Parsedown;
 
 // From 'charcoal-view'
+use Charcoal\View\GenericTemplateRegistry;
 use Charcoal\View\GenericView;
 use Charcoal\View\Mustache\MustacheEngine;
 use Charcoal\View\Mustache\MustacheLoader;
@@ -120,13 +121,22 @@ class ViewServiceProvider implements ServiceProviderInterface
     {
         /**
          * @param Container $container A container instance.
+         * @return GenericTemplateRegistry
+         */
+        $container['view/loader/template-registry'] = function () {
+            return new GenericTemplateRegistry();
+        };
+
+        /**
+         * @param Container $container A container instance.
          * @return array The view loader dependencies array.
          */
         $container['view/loader/dependencies'] = function (Container $container) {
             return [
                 'logger'    => $container['logger'],
                 'base_path' => $container['config']['base_path'],
-                'paths'     => $container['view/config']['paths']
+                'paths'     => $container['view/config']['paths'],
+                'registry'  => $container['view/loader/template-registry'],
             ];
         };
 

--- a/src/Charcoal/View/ViewableTrait.php
+++ b/src/Charcoal/View/ViewableTrait.php
@@ -165,6 +165,24 @@ trait ViewableTrait
     }
 
     /**
+     * @param string $varName The name of the variable to get template ident from.
+     * @return string
+     */
+    public function dynamicTemplate($varName)
+    {
+        return $this->view()->dynamicTemplate($varName);
+    }
+
+    /**
+     * @param string $varName The name of the variable to get template ident from.
+     * @return boolean
+     */
+    public function hasDynamicTemplate($varName)
+    {
+        return $this->view()->hasDynamicTemplate($varName);
+    }
+
+    /**
      * @param string      $varName       The name of the variable to set this template unto.
      * @param string|null $templateIdent The "dynamic template" to set. null to clear.
      * @return void

--- a/tests/Charcoal/View/AbstractLoaderTest.php
+++ b/tests/Charcoal/View/AbstractLoaderTest.php
@@ -10,6 +10,7 @@ use Psr\Log\NullLogger;
 
 // From 'charcoal-view'
 use Charcoal\View\AbstractLoader;
+use Charcoal\View\GenericTemplateRegistry;
 use Charcoal\Tests\AbstractTestCase;
 
 /**
@@ -69,49 +70,10 @@ class AbstractLoaderTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testDynamicTemplateInvalidVarName()
-    {
-        $this->expectException('\InvalidArgumentException');
-        $this->obj->dynamicTemplate(null);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSetDynamicTemplateInvalidVarName()
-    {
-        $this->expectException('\InvalidArgumentException');
-        $this->obj->setDynamicTemplate(null, 'foo');
-    }
-
-    /**
-     * @return void
-     */
     public function testSetDynamicTemplate()
     {
         $this->assertNull($this->obj->setDynamicTemplate('dynamic', 'foo'));
         $this->assertEquals('foo', $this->obj->dynamicTemplate('dynamic'));
-    }
-
-    /**
-     * @return void
-     */
-    public function testSetDynamicTemplateInvalidTemplateIdent()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->obj->setDynamicTemplate('foo', []);
-    }
-
-    /**
-     * @return void
-     */
-    public function testRemoveDynamicTemplate()
-    {
-        $this->obj->setDynamicTemplate('foo', null);
-        $this->obj->removeDynamicTemplate('foo');
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->obj->removeDynamicTemplate(null);
     }
 
     /**


### PR DESCRIPTION
Add support for a dynamic template collector.

Add support for protected partials, partials that unbound after first load.

## Changeset

- Add `LoaderRegistrInterface` for building dynamic template collections
- Replace, internally, `AbstractLoader::$dynamicTemplates` with implementation of `LoaderRegistrInterface`
- Add `GenericTemplateRegistry` for simple template collecting
- Add `DynamicTemplateRegistry` with protection and single-use features
- Add `AbstractLoader::handleNotFound()` to handle missing or unresolved templates

## Todo

- [ ] Add support for `AbstractLoader::handleNotFound()`
- [ ] Add unit tests for template registries
- [ ] Update unit tests for dynamic templates
- [ ] Remove support for `$GLOBALS['widget_template']